### PR TITLE
Hotfix: Prevent FileNotFoundException on Mac/Linux

### DIFF
--- a/VerticalTabs/src/com/abapblog/verticaltabs/tree/memento/MementoOperations.java
+++ b/VerticalTabs/src/com/abapblog/verticaltabs/tree/memento/MementoOperations.java
@@ -8,7 +8,7 @@ public abstract class MementoOperations {
 
 	protected File getMementoFile() {
 		File stateFile = new File(
-				Activator.getDefault().getStateLocation().toString() + "\\contentProviderMemento.xml");
+				Activator.getDefault().getStateLocation().toString(), "contentProviderMemento.xml");
 		return stateFile;
 	}
 


### PR DESCRIPTION
This plugin keeps crashing at random times because of a hardcoded "\\" file separator. This is because every OS other than Windows uses `/` as a path separator and I'm trying to use this amazing plugin from one of them  :¬)

This pull request is for my fellow Machintosh, BSD and Linux users.